### PR TITLE
add .idea to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ nosetests.xml
 coverage.xml
 *,cover
 .hypothesis/
+.idea/
 
 # Translations
 *.mo


### PR DESCRIPTION
`.idea/` kept popping up in my untracked files on git, and I didn't see it on `.gitignore`, so I added it. Not sure if others have this issue.